### PR TITLE
Allow dot and dash in user/group name

### DIFF
--- a/lib/lita/handlers/group_mention.rb
+++ b/lib/lita/handlers/group_mention.rb
@@ -3,9 +3,9 @@ module Lita
   module Handlers
     # GroupMention handler class
     class GroupMention < Handler
-      route(/@(\w+)+/, :group_mention)
+      route(/@([a-zA-Z0-9.\-_]+)+/, :group_mention)
       route(
-        /^group\s+mention\s+add\s+@?(?<user>\w+)\s+to\s+@?(?<group>\w+)/,
+        /^group\s+mention\s+add\s+@?(?<user>[a-zA-Z0-9.\-_]+)\s+to\s+@?(?<group>[a-zA-Z0-9.\-_]+)/,
         :add_member,
         command: true,
         help: {
@@ -13,7 +13,7 @@ module Lita
         }
       )
       route(
-        /^group\s+mention\s+remove\s+@?(?<user>\w+)\s+from\s+@?(?<group>\w+)/,
+        /^group\s+mention\s+remove\s+@?(?<user>[a-zA-Z0-9.\-_]+)\s+from\s+@?(?<group>[a-zA-Z0-9.\-_]+)/,
         :remove_member,
         command: true,
         help: {
@@ -21,7 +21,7 @@ module Lita
         }
       )
       route(
-        /^group\s+mention\s+remove\s+group\s+@?(?<group>\w+)/,
+        /^group\s+mention\s+remove\s+group\s+@?(?<group>[a-zA-Z0-9.\-_]+)/,
         :remove_group,
         command: true,
         help: {
@@ -37,7 +37,7 @@ module Lita
         }
       )
       route(
-        /^group\s+mention\s+show\s+group\s+@?(?<group>\w+)/,
+        /^group\s+mention\s+show\s+group\s+@?(?<group>[a-zA-Z0-9.\-_]+)/,
         :show_group,
         command: true,
         help: {
@@ -45,7 +45,7 @@ module Lita
         }
       )
       route(
-        /^group\s+mention\s+show\s+user\s+@?(?<user>\w+)/,
+        /^group\s+mention\s+show\s+user\s+@?(?<user>[a-zA-Z0-9.\-_]+)/,
         :show_user,
         command: true,
         help: {

--- a/lita-group-mention.gemspec
+++ b/lita-group-mention.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
   spec.files         = `git ls-files`.split($RS)
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.2'

--- a/spec/lita/handlers/group_mention_spec.rb
+++ b/spec/lita/handlers/group_mention_spec.rb
@@ -85,8 +85,8 @@ describe Lita::Handlers::GroupMention, lita_handler: true do
   context 'commands sent without @ mentions' do
     include_examples 'commands' do
       let(:redis) { redis_connection }
-      let(:chat_user) { 'test_user1' }
-      let(:chat_group) { 'test_group1' }
+      let(:chat_user) { 'test_user.1-0' }
+      let(:chat_group) { 'test_group.1-0' }
       let(:command_user) { chat_user }
       let(:command_group) { chat_group }
     end
@@ -95,8 +95,8 @@ describe Lita::Handlers::GroupMention, lita_handler: true do
   context 'commands sent with @ mentions' do
     include_examples 'commands' do
       let(:redis) { redis_connection }
-      let(:chat_user) { 'test_user1' }
-      let(:chat_group) { 'test_group1' }
+      let(:chat_user) { 'test_user.1-0' }
+      let(:chat_group) { 'test_group.1-0' }
       let(:command_user) { '@' + chat_user }
       let(:command_group) { '@' + chat_group }
     end


### PR DESCRIPTION
Hi @bhouse.
We have `-` and `.` everywhere here. The PR should fix #7  
